### PR TITLE
Improve error handling and tests for when API has problems

### DIFF
--- a/handlers/trials.js
+++ b/handlers/trials.js
@@ -1,3 +1,4 @@
+const Boom = require('boom');
 const trials = require('../agents/trials');
 
 function trialsDetails(request, reply) {
@@ -9,7 +10,11 @@ function trialsDetails(request, reply) {
       trial: _trial,
     });
   }).catch((err) => {
-    reply('Trial not found.').code(err.status);
+    if (err.status === 404) {
+      reply(Boom.notFound('Trial not found.', err));
+    } else {
+      reply(Boom.badGateway('Error accessing OpenTrials API.', err));
+    }
   });
 }
 
@@ -20,7 +25,7 @@ function trialsList(request, reply) {
       trials: _trials,
     });
   }).catch((err) => {
-    reply('Failure listing trials.').code(err.status);
+    reply(Boom.badGateway('Error accessing OpenTrials API.', err));
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "should": "^8.2.2"
   },
   "dependencies": {
+    "boom": "^3.1.2",
     "bootstrap": "^3.3.6",
     "del": "^2.2.0",
     "dotenv": "^2.0.0",

--- a/test/handlers/trials.js
+++ b/test/handlers/trials.js
@@ -2,96 +2,102 @@ const server = require('../../server');
 
 describe('trials handler', () => {
   describe('GET /trials', () => {
-    const trials = [
-      fixtures.getTrial(),
-      fixtures.getTrial(),
-    ];
-    let response;
+    describe('API is OK', () => {
+      const trials = JSON.parse(JSON.stringify([
+        fixtures.getTrial(),
+        fixtures.getTrial(),
+      ]));
+      let response;
 
-    before(() => {
-      apiServer.get('/trials').reply(200, trials);
+      before(() => {
+        apiServer.get('/trials').reply(200, trials);
 
-      return server.inject('/trials')
-        .then((_response) => {
-          response = _response;
-        });
+        return server.inject('/trials')
+          .then((_response) => {
+            response = _response;
+          });
+      });
+
+      it('is successful', () => {
+        response.statusCode.should.equal(200)
+      });
+
+      it('uses the "trials-list" template', () => (
+        response.request.response.source.template.should.equal('trials-list')
+      ));
+
+      it('adds the trials into the context', () => {
+        const context = response.request.response.source.context;
+
+        context.trials.should.deepEqual(trials);
+      });
     });
 
-    it('is successful', () => {
-      response.statusCode.should.equal(200)
-    });
+    describe('API is not OK', () => {
+      it('returns error 502', () => {
+        apiServer.get('/trials').reply(500);
 
-    it('uses the "trials-list" template', () => (
-      response.request.response.source.template.should.equal('trials-list')
-    ));
-
-    it('adds the trials into the context', () => {
-      const context = response.request.response.source.context;
-
-      context.trials.map((trial) => {
-        trial.registration_date = new Date(trial.registration_date);
-        return trial;
-      }).should.deepEqual(trials);
-    });
-
-    it('returns api status code when there was a problem with it', () => {
-      apiServer.get('/trials').reply(500);
-
-      return server.inject('/trials')
-        .then((_response) => {
-          _response.statusCode.should.equal(500);
-        });
+        return server.inject('/trials')
+          .then((_response) => {
+            _response.statusCode.should.equal(502);
+          });
+      });
     });
   });
 
   describe('GET /trials/{id}', () => {
-    const trial = fixtures.getTrial();
-    let response;
+    describe('API is OK', () => {
+      const trial = JSON.parse(JSON.stringify(
+        fixtures.getTrial()
+      ));
+      let response;
 
-    before(() => {
-      apiServer.get('/trials/'+trial.id).reply(200, trial);
+      before(() => {
+        apiServer.get('/trials/'+trial.id).reply(200, trial);
 
-      return server.inject('/trials/'+trial.id)
-        .then((_response) => {
-          response = _response;
-        });
+        return server.inject('/trials/'+trial.id)
+          .then((_response) => {
+            response = _response;
+          });
+      });
+
+      it('is successful', () => {
+        response.statusCode.should.equal(200)
+      });
+
+      it('uses the "trials-list" template', () => (
+        response.request.response.source.template.should.equal('trials-details')
+      ));
+
+      it('adds the requested trial to the context', () => {
+        const context = response.request.response.source.context;
+        context.trial.should.deepEqual(trial);
+      });
+
+      it('sets the title to the trial.public_title', () => {
+        const context = response.request.response.source.context;
+        context.title.should.equal(trial.public_title);
+      });
+
+      it('returns 404 when trial doesnt exist', () => {
+        apiServer.get('/trials/foo').reply(404);
+
+        return server.inject('/trials/foo')
+          .then((_response) => {
+            _response.statusCode.should.equal(404);
+          });
+      });
     });
 
-    it('is successful', () => {
-      response.statusCode.should.equal(200)
-    });
+    describe('API is not OK', () => {
+      it('returns error 502', () => {
+        apiServer.get('/trials/foo').reply(500);
 
-    it('uses the "trials-list" template', () => (
-      response.request.response.source.template.should.equal('trials-details')
-    ));
-
-    it('adds the requested trial to the context', () => {
-      const context = response.request.response.source.context;
-      context.trial.registration_date = new Date(context.trial.registration_date);
-      context.trial.should.deepEqual(trial);
-    });
-
-    it('sets the title to the trial.public_title', () => {
-      const context = response.request.response.source.context;
-      context.title.should.equal(trial.public_title);
-    });
-
-    it('returns 404 when trial doesnt exist', () => {
-      apiServer.get('/trials/foo').reply(404);
-
-      return server.inject('/trials/foo')
-        .then((_response) => {
-          _response.statusCode.should.equal(404);
-        });
-    });
-
-    it('returns api status code when there was a problem with it', () => {
-      apiServer.get('/trials/foo').reply(500);
-
-      return server.inject('/trials/foo')
-        .then((_response) => {
-          _response.statusCode.should.equal(500);
-        });
+        return server.inject('/trials/foo')
+          .then((_response) => {
+            _response.statusCode.should.equal(502);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
We're returning HTTP code 502 Bad Gateway for when there were some problems
with the API. This seems to be the best error code, considering that this app
is basically a gateway to the OpenTrials API.

I've also refactored how we test for the responses. We have to do
`JSON.parse(JSON.stringify(data))` to convert JavaScript primitives (like Date)
into JSON. It's better to do that than to manually convert the dates to a
string before checking for the API response, as we were doing before, because
we would have to keep track of what fields need to be converted. Converting to
JSON allows us not to care about this.