### PR TITLE
[#50] Add Trials' discrepancies page

### DIFF
--- a/handlers/trials.js
+++ b/handlers/trials.js
@@ -39,7 +39,26 @@ function getRecord(request, reply) {
   });
 }
 
+function getDiscrepancies(request, reply) {
+  const id = request.params.id;
+
+  trials.getDiscrepancies(id).then((discrepancies) => {
+    reply.view('trial-discrepancies', {
+      title: 'Discrepancies',
+      trial_id: id,
+      discrepancies,
+    });
+  }).catch((err) => {
+    if (err.status === 404) {
+      reply(Boom.notFound('Trial discrepancies not found.', err));
+    } else {
+      reply(Boom.badGateway('Error accessing OpenTrials API.', err));
+    }
+  });
+}
+
 module.exports = {
   getTrial,
   getRecord,
+  getDiscrepancies,
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -31,6 +31,11 @@ const routes = [
     handler: require('../handlers/trials').getTrial,
   },
   {
+    path: '/trials/{id}/discrepancies',
+    method: 'GET',
+    handler: require('../handlers/trials').getDiscrepancies,
+  },
+  {
     path: '/trials/{trialId}/records/{id}',
     method: 'GET',
     handler: require('../handlers/trials').getRecord,

--- a/test/fixtures/api/swagger.yaml
+++ b/test/fixtures/api/swagger.yaml
@@ -172,6 +172,27 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
 
+  /trials/{id}/records:
+    x-swagger-router-controller: trials
+    get:
+      tags:
+        - trials
+      description: Returns all trial's raw records from its sources
+      operationId: getRecords
+      parameters:
+        - name: id
+          in: path
+          description: ID of the trial
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/RecordList"
+        "404":
+          description: Trial not found
+
   /trials/{trialId}/records/{id}:
     x-swagger-router-controller: trials
     get:
@@ -341,6 +362,7 @@ definitions:
       - public_title
       - brief_summary
       - registration_date
+      - has_discrepancies
       - locations
       - interventions
       - persons
@@ -366,6 +388,9 @@ definitions:
           - female
       has_published_results:
         type: boolean
+      has_discrepancies:
+        type: boolean
+        description: Describes if there are any data discrepancies among the sources of this Trial.
       registration_date:
         type: string
         format: date-time
@@ -408,10 +433,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -424,10 +452,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -439,15 +470,18 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
         type: string
+      url:
+        type: string
 
   TrialPerson:
     allOf:
-      - $ref: '#/definitions/Location'
+      - $ref: '#/definitions/Person'
       - type: object
         properties:
           role:
@@ -461,10 +495,13 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
+        type: string
+      url:
         type: string
       type:
         type: string
@@ -473,7 +510,7 @@ definitions:
 
   TrialOrganisation:
     allOf:
-      - $ref: '#/definitions/Location'
+      - $ref: '#/definitions/Organisation'
       - type: object
         properties:
           role:
@@ -487,11 +524,19 @@ definitions:
     required:
       - id
       - name
+      - url
     properties:
       id:
         type: string
       name:
         type: string
+      url:
+        type: string
+
+  RecordList:
+    type: array
+    items:
+      $ref: '#/definitions/Record'
 
   Record:
     required:

--- a/test/fixtures/trials.js
+++ b/test/fixtures/trials.js
@@ -14,6 +14,7 @@ function getTrial() {
     study_type: 'study_type',
     study_design: 'study_design',
     study_phase: 'study_phase',
+    gender: 'both',
   };
 
   return trial;
@@ -38,6 +39,7 @@ function getRecord() {
     registration_date: new Date('2016-01-01'),
     created_at: new Date('2016-01-01'),
     updated_at: new Date('2016-02-01'),
+    gender: 'both',
   };
   record.trial_url = `http://api.opentrials.net/v1/trials/${record.trial_id}`;
   record.url = `${record.trial_url}/records/${record.id}`;

--- a/views/trial-discrepancies.html
+++ b/views/trial-discrepancies.html
@@ -1,0 +1,27 @@
+{% extends 'layouts/base.html' %}
+
+{% block main %}
+<article class="record-data">
+{% if discrepancies.length == 0 %}
+There are no discrepancies in this Trial's records.
+{% else %}
+<dl>
+  {% for discrepancy in discrepancies %}
+    <dt>{{ discrepancy.field | underscoresToCapitalized }}<dt>
+    <dd>
+      <dl>
+      {% for record in discrepancy.records %}
+        <dt>
+          <a href="/trials/{{ trial_id }}/records/{{ record.id }}">
+            {{ record.source_name }}
+          </a>
+        </dt>
+        <dd>{{ record.value or 'N/A' }}</dd>
+      {% endfor %}
+      </dl>
+    <dd>
+  {% endfor %}
+</dl>
+{% endif %}
+</article>
+{% endblock %}

--- a/views/trials-details.html
+++ b/views/trials-details.html
@@ -92,6 +92,9 @@
     <li>
       <a href="{{ trial.url }}" class="download">Download JSON</a>
       <a href="{{ contributeDataUrl }}" class="upload">Contribute Data</a>
+      {% if trial.has_discrepancies %}
+        <a href="/trials/{{ trial.id }}/discrepancies">Data discrepancies</a>
+      {% endif %}
     </li>
   </ul>
 


### PR DESCRIPTION
@roll This is the Explorer-side of the discrepancies. It basically generates the discrepancies dynamically in `agents/trials.js#getDiscrepancies`, following a structure similar to what you've done for the `discrepancies` table.

Again, as this is dynamically generated, we might have a performance hit. I'm not concerned with it, though, because I think it would be easy to add caching later :+1:

Thoughts?