### PR TITLE
Fix flashes of unstyled parts of the page

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -52,7 +52,8 @@ $(document).ready(function() {
   });
 
   // home page
-  $(".toggle-advanced").click(function() {
+  $(".toggle-advanced").click(function(e) {
+    e.preventDefault();
     $(".advanced").slideToggle("slow", function() {
       $(".home").toggleClass("advanced-search")
     });

--- a/assets/styles/ot-scss/_header.scss
+++ b/assets/styles/ot-scss/_header.scss
@@ -269,6 +269,10 @@ html.mm-opened .show-menu {
   }
 }
 
+#menu:not(.mm-menu) {
+  display: none;
+}
+
 nav .more {
   a {
     cursor: pointer;

--- a/assets/styles/ot-scss/_search-bar.scss
+++ b/assets/styles/ot-scss/_search-bar.scss
@@ -57,6 +57,12 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 
 .advanced {
+  display: none;
+
+  &.visible {
+    display: block;
+  }
+
   & > div {
     margin-bottom: $small-spacing;
 
@@ -98,16 +104,6 @@ input[type="search"]::-webkit-search-cancel-button {
     #clear-fieldset {
       color: inherit;
       background-color: $dark-blue;
-    }
-  }
-}
-
-.js {
-  .advanced {
-    display: none;
-
-    &.visible {
-      display: block;
     }
   }
 }

--- a/handlers/homepage.js
+++ b/handlers/homepage.js
@@ -1,9 +1,19 @@
 'use strict';
 
+const Joi = require('joi');
+
 function homepage(request, reply) {
   reply.view('index', {
     title: 'OpenTrials.net',
+    advancedSearchIsVisible: request.query.advanced_search,
   });
 }
 
-module.exports = homepage;
+module.exports = {
+  handler: homepage,
+  validate: {
+    query: {
+      advanced_search: Joi.boolean().default(false),
+    },
+  },
+};

--- a/handlers/search.js
+++ b/handlers/search.js
@@ -109,6 +109,7 @@ function searchPage(request, reply) {
   const perPage = 10;
   const maxPages = 100;
   const filters = getFilters(query);
+  const advancedSearch = query.advanced_search || (Object.keys(filters).length > 0);
 
   trials.search(queryStr, page, perPage, filters).then((_trials) => {
     const currentPage = page || 1;
@@ -121,7 +122,7 @@ function searchPage(request, reply) {
       query,
       currentPage,
       pagination,
-      advancedSearchIsVisible: Object.keys(filters).length > 0,
+      advancedSearchIsVisible: advancedSearch,
       trials: _trials,
     });
   }).catch((err) => (
@@ -135,6 +136,7 @@ module.exports = {
   handler: searchPage,
   validate: {
     query: {
+      advanced_search: Joi.boolean().default(false),
       page: Joi.number().integer().min(1).max(100),
       registration_date_start: Joi.date().format('YYYY-MM-DD').empty('').raw(),
       registration_date_end: Joi.date().format('YYYY-MM-DD').empty('').raw(),

--- a/routes/index.js
+++ b/routes/index.js
@@ -18,7 +18,7 @@ const routes = [
   {
     path: '/',
     method: 'GET',
-    handler: require('../handlers/homepage'),
+    config: require('../handlers/homepage'),
   },
   {
     path: '/about',

--- a/test/common.js
+++ b/test/common.js
@@ -27,22 +27,30 @@ function clearDB() {
 }
 
 function mockApiResponses(responses) {
+  // When "responses" is undefined, mocks all API responses
   const defaultResponses = {
     search: {
-      query: {
-        per_page: 10,
-      },
       response: { total_count: 0, items: [] },
       statusCode: 200,
     },
   };
   const theResponses = _.merge({}, defaultResponses, responses);
+  if (theResponses.search.query && theResponses.search.query.per_page === undefined) {
+    theResponses.search.query.per_page = 10;
+  }
 
   for (const endpoint of Object.keys(defaultResponses)) {
     const endpointResponse = theResponses[endpoint];
+    let query = endpointResponse.query;
+    if (query) {
+      query = _.omitBy(query, _.isUndefined);
+    } else {
+      // Ignore query values
+      query = true;
+    }
 
     apiServer.get(`/${endpoint}`)
-      .query(endpointResponse.query)
+      .query(query)
       .reply(endpointResponse.statusCode, endpointResponse.response);
   }
 }

--- a/test/handlers/homepage.js
+++ b/test/handlers/homepage.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const server = require('../../server');
 
 describe('homepage handler', () => {
@@ -24,6 +25,24 @@ describe('homepage handler', () => {
     it('sets the title', () => {
       const context = response.request.response.source.context;
       context.should.have.property('title');
+    });
+  });
+
+  describe('GET /?advanced_search={advanced_search}', () => {
+    it('sets advancedSearchIsVisible to false by default', () => {
+      return server.inject('/')
+        .then((response) => {
+          const context = response.request.response.source.context;
+          should(context.advancedSearchIsVisible).be.false();
+        });
+    });
+
+    it('sets advancedSearchIsVisible to true when advanced_search is true', () => {
+      return server.inject('/?advanced_search=true')
+        .then((response) => {
+          const context = response.request.response.source.context;
+          should(context.advancedSearchIsVisible).be.true();
+        });
     });
   });
 });

--- a/test/handlers/search.js
+++ b/test/handlers/search.js
@@ -1,4 +1,6 @@
 'use strict';
+
+const should = require('should');
 const server = require('../../server');
 
 describe('search handler', () => {
@@ -797,6 +799,28 @@ describe('search handler', () => {
         .then((_response) => {
           _response.statusCode.should.equal(200)
           _response.request.response.source.context.advancedSearchIsVisible.should.equal(true);
+        });
+    });
+  });
+
+  describe('GET /search?advanced_search{advancedSearch}', () => {
+    it('sets advancedSearchIsVisible to true when advanced_search is true', () => {
+      mockApiResponses();
+
+      return server.inject('/search?advanced_search=true')
+        .then((response) => {
+          const context = response.request.response.source.context;
+          should(context.advancedSearchIsVisible).be.true();
+        });
+    });
+
+    it('ignores advanced_search when there are filters', () => {
+      mockApiResponses();
+
+      return server.inject('/search?advanced_search=false&location=UK')
+        .then((response) => {
+          const context = response.request.response.source.context;
+          should(context.advancedSearchIsVisible).be.true();
         });
     });
   });

--- a/views/layouts/base.html
+++ b/views/layouts/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="en">
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/views/layouts/index.html
+++ b/views/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js home" lang="en">
+<html class="home" lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/views/partials/scripts.html
+++ b/views/partials/scripts.html
@@ -1,4 +1,3 @@
-<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js" defer async></script>
 <script src="//a.okfn.org/html/oki/panel/assets/js/frontend.js" defer async></script>
 <!--[if lte IE 9]>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>

--- a/views/partials/search-form-fields.html
+++ b/views/partials/search-form-fields.html
@@ -20,7 +20,7 @@
   <button type="submit"><span>Search</span></button>
 </fieldset>
 <div class="search-controls">
-  <a class="toggle-advanced">Advanced search</a>
+  <a href="?advanced_search=true" class="toggle-advanced">Advanced search</a>
 
   {% if trials %}
     <ul class="breadcrumb">


### PR DESCRIPTION
This fixes both the flash of the mobile menu and the one of the advanced search. The advanced search has a drawback: after this patch, it won't be possible for users with JS disabled to use the advanced search.

I think nowadays we can safely assume that the vast majority of our users will have JS enabled, so it's OK. I have coded a workaround to allow non-JS users to also access the advanced search but, after thinking a bit more, I thought it wasn't necessary.

@smth We were using Modernizr here to only hide the advanced search fields when JS is enabled. Do you remember if we're using it in other places as well, or we can remove it?