### PR TITLE
[#282 #283] Footer links for takedown requests and errors flagging

### DIFF
--- a/assets/styles/ot-scss/_footer.scss
+++ b/assets/styles/ot-scss/_footer.scss
@@ -26,6 +26,20 @@ body {
       }
     }
 
+    div.footer-links {
+      float: right;
+      a {
+        font-size: .9em;
+        margin-right: 16px;
+        &:hover {
+          text-decoration: underline;
+        }
+        &:last-child {
+          padding-right: 0;
+        }
+      }
+    }
+
     hr {
       margin: 1em 0;
       opacity: 0.5;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -2,6 +2,7 @@
 
 const plugins = {
   addFlashMessagesToContext: require('./plugins/add-flash-messages-to-context'),
+  addCurrentURLToContext: require('./plugins/add-current-url-to-context'),
   httpErrorHandler: require('./plugins/http-error-handler'),
 };
 

--- a/lib/plugins/add-current-url-to-context.js
+++ b/lib/plugins/add-current-url-to-context.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function addCurrentURLToContext(request, reply) {
+  const response = request.response;
+  const currentURL = `${request.headers['x-forwarded-proto'] || request.connection.info.protocol}://${request.info.host}${request.url.path}`;
+
+  if (response.variety === 'view') {
+    response.source.context = Object.assign(
+      {},
+      response.source.context || {},
+      { currentURL }
+    );
+  }
+
+  return reply.continue();
+}
+
+module.exports = addCurrentURLToContext;

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ server.connection({
 
 server.ext('onPreResponse', plugins.addFlashMessagesToContext);
 server.ext('onPreResponse', plugins.httpErrorHandler);
+server.ext('onPreResponse', plugins.addCurrentURLToContext);
 
 server.register(config.hapi.plugins)
   .then(() => {

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -4,6 +4,15 @@
         <img alt="Open Knowledge" src="/assets/images/ok-logo.png">
     </a>
 
+    <div class="footer-links">
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSew2Rsu5EY-SYODFzZCh2wMWKcbcJe5CQlMFoyH8shmIE1jfQ/viewform?entry.579116872={{currentURL}}" target="_blank" rel="external">
+        Takedown request
+      </a>
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLSc49nJx0Ie8q8b24yYNX2DrqIWN44P9DsF9k4Y_VkU7y81rFg/viewform?entry.783048384={{currentURL}}" target="_blank" rel="external">
+        Flag an error
+      </a>
+    </div>
+
     <hr />
 
     <a class="cc" href="http://creativecommons.org/licenses/by/4.0/" rel="external">


### PR DESCRIPTION
This adds the links for takedown requests and error flagging, by injecting the currently requested URL into the page context then passing it as a query string parameter to Google Forms.

This fixes #282 and #283.

* New plugin to add `currentURL` variable into the view context
* Links to the respective Google Forms that collect the information
* Small SCSS additions to accommodate the footer anchors