### PR TITLE
Minor UI tweaks

### DIFF
--- a/test/e2e/search.js
+++ b/test/e2e/search.js
@@ -26,9 +26,8 @@ describe('(e2e) search', function() {
     driver.get(SERVER_URL);
     driver.findElement(By.css('.search-bar input')).submit();
     driver.findElement(By.css('.search-results .title a')).click();
-    driver.findElement(By.css('.actions .download')).click();
-    return driver.getPageSource()
-      .then((body) => should(body).not.containEql('"error"'))
+    return driver.getCurrentUrl()
+      .then((url) => should(url).match(/\/trials\//));
   });
 
   it('should work with all search filters enabled', () => {

--- a/views/partials/entity-details.html
+++ b/views/partials/entity-details.html
@@ -35,7 +35,6 @@
 <aside>
   <ul class="actions">
     <li>
-      <a href="{{ api_url }}" class="download">Download JSON</a>
       <a href="/contribute-data" class="upload">Contribute Data</a>
     </li>
   </ul>

--- a/views/publications-details.html
+++ b/views/publications-details.html
@@ -16,7 +16,6 @@
 
 <aside>
   <ul class="actions">
-    <a href="{{ publication.url }}" class="download">Download JSON</a>
     <a href="/contribute-data" class="upload">Contribute Data</a>
   </ul>
 

--- a/views/trials-details.html
+++ b/views/trials-details.html
@@ -166,7 +166,6 @@
 <aside>
   <ul class="actions">
     <li>
-      <a href="{{ trial.url }}" class="download">Download JSON</a>
       <a href="{{ contributeDataUrl }}" class="upload">Contribute Data</a>
       {% if trial.discrepancies %}
         <a href="/trials/{{ trial.id }}/discrepancies" class="discrepancies">Discrepancies</a>

--- a/views/trials-details.html
+++ b/views/trials-details.html
@@ -161,6 +161,22 @@
       </section>
     {% endfor %}
   </p>
+
+  {% if trial.records.length != 0 %}
+  <h2>Sources</h2>
+  <ul class="overview-list">
+    {% for record in trial.records %}
+      <li>
+        <a href="{{ record.source_url }}"
+           title="Last updated on {{ record.updated_at | formatDate }}">
+          {{ record.source.name }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+  {{ no_data_message('Sources', thing='"sources"') }}
+  {% endif %}
 </article>
 
 <aside>
@@ -241,25 +257,6 @@
   </dl>
   {% else %}
   {{ no_data_message('Related Organisations', thing='"related organisations"') }}
-  {% endif %}
-
-  {% if trial.records.length != 0 %}
-  <h2>Sources</h2>
-  <dl>
-    {% for record in trial.records %}
-      <dt>
-        <a href="/trials/{{ trial.id }}/records/{{ record.id }}">{{ record.source.name }}</a>
-      </dt>
-      <dd>
-        Last updated on
-        <time datetime="{{ record.updated_at }}">
-          {{ record.updated_at | formatDate }}
-        </time>
-      </dd>
-    {% endfor %}
-  </dl>
-  {% else %}
-  {{ no_data_message('Sources', thing='"sources"') }}
   {% endif %}
 
   {% if trial.publications.length != 0 %}


### PR DESCRIPTION
I wanted to get us closer to the mockup's UI:

![mockup UI](https://cloud.githubusercontent.com/assets/76945/18058816/eec59520-6e0d-11e6-8736-2475239b103a.png)

The biggest change here is to move the "Data" documents to the upper part of the page, and moving them as top-down instead of sideways. I prefered not to do so now because I think it'll end up looking a bit odd when displaying trials with "unbalanced" documents. Having it sideways is more resilient in my opinion.

I also changed the sources list to link directly to the source URL, and not our record's page. This means that there's no way to access the record's pages now. We can leave it as is for now but, if this becomes our intended solution, we should remove the handlers/views that aren't needed anymore. Also, I didn't rename "Sources" to "Registries" because we have sources that aren't registries.