### PR TITLE
Escape text queries on FDA page

### DIFF
--- a/agents/fda_documents.js
+++ b/agents/fda_documents.js
@@ -3,11 +3,12 @@
 const opentrialsApi = require('../config').opentrialsApi;
 const decorateFDADocument = require('../presenters/fda_document');
 const generateESQueryString = require('../helpers/generate-es-query-string');
+const escapeElasticSearch = require('../helpers/escape-elastic-search');
 
 function searchFDADocuments(query, text, page, perPage, filters) {
   const searchQuery = {
     q: generateESQueryString(query, filters),
-    text,
+    text: escapeElasticSearch(text),
     page,
     per_page: perPage,
   };

--- a/helpers/escape-elastic-search.js
+++ b/helpers/escape-elastic-search.js
@@ -1,10 +1,16 @@
 'use strict';
 
 function escapeElasticSearch(query) {
-  return query
-    .replace(/[*+\-"~?^{}():!/[\]\\]/g, '\\$&')
-    .replace(/\|\|/g, '\\||')
-    .replace(/&&/g, '\\&&');
+  let result;
+
+  if (query !== undefined) {
+    result = query
+      .replace(/[*+\-"~?^{}():!/[\]\\]/g, '\\$&')
+      .replace(/\|\|/g, '\\||')
+      .replace(/&&/g, '\\&&');
+  }
+
+  return result;
 }
 
 module.exports = escapeElasticSearch;

--- a/test/agents/fda_documents.js
+++ b/test/agents/fda_documents.js
@@ -36,6 +36,12 @@ describe('FDA Documents', () => {
       return should(fdaDocuments.search(undefined, 'foo bar')).be.fulfilledWith(expectedResponse);
     });
 
+    it('escapes the text query', () => {
+      apiServer.get('/search/fda_documents').query({text: 'foo\\('}).reply(200, response);
+
+      return should(fdaDocuments.search(undefined, 'foo(')).be.fulfilledWith(expectedResponse);
+    });
+
     it('passes the page number to the query', () => {
       apiServer.get('/search/fda_documents').query({page: 2}).reply(200, response);
 

--- a/test/helpers/escape-elastic-search.js
+++ b/test/helpers/escape-elastic-search.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const should = require('should');
 const escapeElasticSearch = require('../../helpers/escape-elastic-search');
 
 describe('escapeElasticSearch', () => {
@@ -31,5 +32,9 @@ describe('escapeElasticSearch', () => {
     const output = input;
 
     escapeElasticSearch(input).should.eql(output);
+  });
+
+  it('returns undefined if called with undefined', () => {
+    should(escapeElasticSearch(undefined)).be.undefined();
   });
 });


### PR DESCRIPTION
This avoids a query like "foo(" returning a 500 error. We do the same for the
other filters. You can reproduce the error by going to https://fda.opentrials.net/search?text=foo(.