### PR TITLE
Add presentation link and "Vote now" menu item

### DIFF
--- a/views/fda/about.html
+++ b/views/fda/about.html
@@ -100,8 +100,9 @@
 
     <ul>
       <li>
-        <time datetime="2016-12-01">December 2016</time>: OpenTrialsFDA presents prototype as finalist for the Open
-        Science Prize (link coming on 1 Dec)
+        <time datetime="2016-12-01">December 2016</time>: <a
+          href="http://opentrials.net/2016/12/01/opentrialsfda-presents-prototype-as-finalist-for-the-open-science-prize/"
+          rel="external">OpenTrialsFDA presents prototype as finalist for the Open Science Prize</a>
       </li>
       <li>
         <time datetime="2016-10-25">October 2016</time>: <a

--- a/views/fda/partials/main-menu.html
+++ b/views/fda/partials/main-menu.html
@@ -17,4 +17,11 @@
       </a>
     </li>
   </ul>
+  <li>
+    <a href="http://event.capconcorp.com/wp/osp/vote-now/"
+      rel="external"
+      target="_blank">
+      Vote now
+    </a>
+  </li>
 </li>

--- a/views/layouts/base.html
+++ b/views/layouts/base.html
@@ -24,7 +24,6 @@
     <div class="page">
       <div id="ok-panel" class="closed"><div class="container"><iframe src="//a.okfn.org/html/oki/panel/panel.html" scrolling="no"></iframe></div></div>
       {% include "partials/under-construction-disclaimer.html" %}
-      {% include "partials/vote-for-us.html" %}
       {% include "partials/flash-messages.html" %}
       {% block header %}
         {% include "partials/header.html"  %}

--- a/views/partials/vote-for-us.html
+++ b/views/partials/vote-for-us.html
@@ -1,5 +1,0 @@
-<div class="under-construction">
-  <span>
-    <a href="http://event.capconcorp.com/wp/osp/vote-now/">Vote for us in the Open Science Prize!</a>
-  </span>
-</div>


### PR DESCRIPTION
Two small modifications:

* Added a link to the article covering the OSP presentation
* ...and a "Vote now" menu item:

![image](https://cloud.githubusercontent.com/assets/1579997/20834785/b5ba28cc-b89f-11e6-9e4a-4ce0529050e6.png)
