### PR TITLE
Add the URL for data contributions

### DIFF
--- a/assets/styles/ot-scss/_data-curation.scss
+++ b/assets/styles/ot-scss/_data-curation.scss
@@ -1,4 +1,11 @@
 .data-curation {
+  font-size: .8em;
+
+  td {
+    padding: .5em;
+    word-wrap: break-word;
+  }
+
   td,
   th,
   tr {

--- a/views/admin/data-contributions.html
+++ b/views/admin/data-contributions.html
@@ -8,7 +8,7 @@
       <th>Approved?</th>
       <th>User</th>
       <th>Trial</th>
-      <th>File</th>
+      <th>File / URL</th>
       <th>Category</th>
       <th>Date</th>
       <th class="comments-col">Comments</th>
@@ -28,9 +28,13 @@
 
       <td>
         {% if dataContribution.user %}
-          <a href="mailto:{{ dataContribution.user.email }}">
-            {{ dataContribution.user.name }}
-          </a>
+          {% if dataContribution.user.email %}
+            <a href="mailto:{{ dataContribution.user.email }}">
+              {{ dataContribution.user.name }}
+            </a>
+          {% else %}
+            <span>Anonymous</span>
+          {% endif %}
         {% endif %}
       </td>
       <td>
@@ -41,9 +45,18 @@
         {% endif %}
       </td>
       <td>
-        <a href="{{ dataContribution.data_url }}">
-          {{ dataContribution.filename }}
-        </a>
+        {% if dataContribution.data_url %}
+          <span>File: </span>
+          <a href="{{ dataContribution.data_url }}">
+            {{ dataContribution.filename }}
+          </a><br/>
+        {% endif %}
+        {% if dataContribution.url %}
+          <span>URL: </span>
+          <a href="{{ dataContribution.url }}">
+            {{ dataContribution.url }}
+          </a>
+        {% endif %}
       </td>
       <td>
         {{ dataContribution.category.name }}


### PR DESCRIPTION
Made a few modifications to the data contributions template, which seems to be needing a lot of love. The important thing here is that I added the URL for URL-only data contributions and made the font smaller so it won't be such a horrible curating experience:

![image](https://cloud.githubusercontent.com/assets/1579997/21149859/9700b580-c165-11e6-9a1b-e8f85d9768be.png)

