### PR TITLE
[#466] Remove discrepancies link for trials that don't have any

### DIFF
--- a/presenters/trial.js
+++ b/presenters/trial.js
@@ -96,7 +96,7 @@ function decorateResearchSummaries(publications) {
 }
 
 function decorateDiscrepancies(discrepancies, records) {
-  const decoratedDiscrepancies = {};
+  let decoratedDiscrepancies = {};
   const recordsById = _.groupBy(records, 'id');
 
   for (const key of Object.keys(discrepancies)) {
@@ -107,6 +107,9 @@ function decorateDiscrepancies(discrepancies, records) {
     });
   }
 
+  if (_.isEmpty(decoratedDiscrepancies)) {
+    decoratedDiscrepancies = undefined;
+  }
   return decoratedDiscrepancies;
 }
 

--- a/test/presenters/trial.js
+++ b/test/presenters/trial.js
@@ -248,6 +248,20 @@ describe('trial presenter', () => {
       const expectedSourcesUrls = trialAttributes.records.map((record) => record.source_url);
       should(discrepanciesSourcesUrls).deepEqual(expectedSourcesUrls);
     });
+
+    it('returns undefined if there are no discrepancies', () => {
+      const trialAttributes = {
+        records: [
+          {
+            id: '3e5ffed2-5a62-4a99-ba4c-e616567ccdaf',
+            source_url: 'http://example.org/record1',
+          },
+        ],
+      };
+
+      const trial = trialPresenter(trialAttributes);
+      should(trial.discrepancies).be.undefined;
+    });
   });
 
   describe('risks_of_bias', () => {

--- a/views/trial-discrepancies.html
+++ b/views/trial-discrepancies.html
@@ -14,7 +14,7 @@
     For a trial with multiple data sources, occasionally a particular piece of data (e.g. number of participants) differs between registries for that trial -  we consider this a <em>discrepancy</em>. Below are the discrepancies for this <a href="/trials/{{ trial.id }}">trial</a>.
   </p>
   {% if not trial.discrepancies %}
-  There are no discrepancies in this Trial's records.
+  <p>There are no discrepancies in this Trial's records.</p>
   {% else %}
   {% for field, discrepantRecords in trial.discrepancies %}
 


### PR DESCRIPTION
opentrials/opentrials#466

The issue was caused by the fact that [this `if trial.discrepancies` check](https://github.com/opentrials/opentrials/blob/master/views/trials-details.html#L240) always passes even if `discrepancies` is an empty object: 

```
> let a = {};
undefined
> if (a) {console.log('evaluated true')};
evaluated true
undefined
```
Because checking for empty objects is more complicated to do in the views, I changed `decoratedDiscrepancies` to return `undefined` when there are no discrepancies. 