### PR TITLE
New data contributions categories

### DIFF
--- a/migrations/20161220185639_data_contributions_categories_groups.js
+++ b/migrations/20161220185639_data_contributions_categories_groups.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.up = (knex, Promise) => {
+  knex.schema
+    .table('data_contributions', (table) => {
+      table.text('group')
+        .nullable();
+    });
+};
+
+exports.down = (knex, Promise) => {
+  knex.schema
+    .table('data_contributions', (table) => {
+      table.dropColumns([
+        'group',
+      ]);
+    });
+};

--- a/migrations/20161220185639_data_contributions_categories_groups.js
+++ b/migrations/20161220185639_data_contributions_categories_groups.js
@@ -1,18 +1,25 @@
 'use strict';
 
-exports.up = (knex, Promise) => {
-  knex.schema
-    .table('data_contributions', (table) => {
-      table.text('group')
-        .nullable();
-    });
-};
+exports.up = (knex) => knex
+  .schema
+  .table('data_categories', (table) => {
+    table.text('group')
+      .nullable();
+  })
+  .alterTable('data_categories', (table) => {
+    table.unique(['name', 'group']);
+    table.dropUnique('name');
+  });
 
-exports.down = (knex, Promise) => {
-  knex.schema
-    .table('data_contributions', (table) => {
-      table.dropColumns([
-        'group',
-      ]);
-    });
-};
+
+exports.down = (knex) => knex
+  .schema
+  .alterTable('data_categories', (table) => {
+    table.dropUnique(['name', 'group']);
+    table.unique('name');
+  })
+  .table('data_categories', (table) => {
+    table.dropColumns([
+      'group',
+    ]);
+  });

--- a/migrations/20170103182459_data_categories_remapping.js
+++ b/migrations/20170103182459_data_categories_remapping.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const _ = require('lodash');
+
+const newCategories = [
+  { name: 'Registry entry',
+    group: '',
+    replaces: ['Registry entry'] },
+  { name: 'Other',
+    group: '',
+    replaces: [
+      'Other',
+      'Publication (press release, article, blog post, etc.)',
+      'Trial webpage',
+      'Condition',
+      'Intervention',
+    ] },
+
+  { name: 'Journal article',
+    group: 'Results' },
+  { name: 'Clinical study report',
+    group: 'Results',
+    replaces: ['Clinical study report'] },
+  { name: 'Clinical study report synopsis',
+    group: 'Results',
+    replaces: ['Clinical study report synopsis'] },
+  { name: 'European Public Assessment Report (EPAR) document section',
+    group: 'Results',
+    replaces: ['European Public Assessment Report (EPAR) document'] },
+  { name: 'U.S. Food and Drug Administration (FDA) document segment',
+    group: 'Results',
+    replaces: ['U.S. Food and Drug Administration (FDA) document'] },
+  { name: 'Press release describing results',
+    group: 'Results' },
+  { name: 'Conference abstract or proceedings describing results',
+    group: 'Results' },
+  { name: 'Report to funder',
+    group: 'Results' },
+
+  { name: 'Case report form',
+    group: 'Study documents',
+    replaces: ['Case report forms'] },
+  { name: 'Grant application',
+    group: 'Study documents' },
+  { name: 'IRB/HREC approval documents',
+    group: 'Study documents' },
+  { name: 'Investigator\'s Brochure',
+    group: 'Study documents' },
+  { name: 'Patient information sheet / Consent form',
+    group: 'Study documents',
+    replaces: ['Patient information sheet', 'Consent forms'] },
+  { name: 'Statistical analysis plan',
+    group: 'Study documents',
+    replaces: ['Statistical analysis plan'] },
+  { name: 'Trial protocol',
+    group: 'Study documents',
+    replaces: ['Trial protocols'] },
+  { name: 'Analytic code',
+    group: 'Study documents',
+    replaces: ['Analytics code'] },
+  { name: 'Trialists\'\' webpage',
+    group: 'Study documents',
+    replaces: ['Trial webpage'] },
+
+  { name: 'Lay summary, design of ongoing study',
+    group: 'Lay summaries' },
+  { name: 'Lay summary, results of completed study',
+    group: 'Lay summaries',
+    replaces: ['Lay summaries'] },
+
+  { name: 'Link to individual patient data for trial',
+    group: 'Data' },
+  { name: 'Structured data about trial extracted for systematic review',
+    group: 'Data' },
+
+  { name: 'Blog about trial design or results',
+    group: 'Miscellaneous' },
+  { name: 'Journal article critiquing trial design or results',
+    group: 'Miscellaneous',
+    replaces: ['Critical review'] },
+  { name: 'Systematic review including trial',
+    group: 'Miscellaneous' },
+  { name: 'Review article citing trial',
+    group: 'Miscellaneous' },
+  { name: 'News article about trial or results',
+    group: 'Miscellaneous' },
+  { name: 'Press release about trial',
+    group: 'Miscellaneous' },
+  { name: 'Report from sponsor describing trial or results',
+    group: 'Miscellaneous' },
+];
+
+const toInsert = _.map(newCategories, (obj) => _.omit(obj, ['replaces']));
+const toReplace = _.filter(newCategories, 'replaces');
+const toDelete = _.reject(newCategories, (obj) => obj.replaces);
+
+exports.up = (knex) => knex
+  .batchInsert('data_categories', toInsert, 50)
+  .then(() =>
+        _.map(toReplace, (category) =>
+              category.replaces.forEach((oldName) => knex
+                                        .raw(`UPDATE data_contributions
+                                              SET data_category_id = (SELECT id FROM data_categories
+                                                            WHERE name = '${category.name}'
+                                                            AND "group" = '${category.group}')
+                                              WHERE data_category_id = (SELECT id FROM data_categories
+                                                            WHERE name = '${oldName}'
+                                                            AND "group" IS NULL);`)
+                                        .then(() => knex
+                                              .raw(`DELETE FROM data_categories
+                                                    WHERE name = '${oldName}' AND "group" IS NULL;`))
+        )
+      )
+    );
+
+exports.down = (knex) => {
+  const toRestore = [
+    { name: 'Consent forms', group: null },
+    { name: 'Publication (press release, article, blog post, etc.)', group: null },
+    { name: 'Condition', group: null },
+    { name: 'Intervention', group: null },
+  ];
+
+  return knex.batchInsert('data_categories', toRestore, 50)
+    .then(() => {
+      const replaceAction = _.map(toReplace, (category) =>
+                                  knex('data_categories')
+                                  .where({ name: category.name, group: category.group })
+                                  .update({ name: category.replaces[0] })
+                                  .then()
+      );
+
+      const deleteAction = _.map(toDelete, (category) =>
+                                 knex('data_categories')
+                                 .where({ name: category.name, group: category.group })
+                                 .del()
+                                 .then()
+      );
+
+      return replaceAction && deleteAction;
+    });
+};
+
+exports.config = { transaction: false };

--- a/migrations/20170103182459_data_categories_remapping.js
+++ b/migrations/20170103182459_data_categories_remapping.js
@@ -44,7 +44,7 @@ const newCategories = [
     group: 'Study documents' },
   { name: 'IRB/HREC approval documents',
     group: 'Study documents' },
-  { name: 'Investigator\'s Brochure',
+  { name: 'Investigator\'\'s Brochure',
     group: 'Study documents' },
   { name: 'Patient information sheet / Consent form',
     group: 'Study documents',
@@ -130,11 +130,17 @@ exports.down = (knex) => {
                                   .then()
       );
 
-      const deleteAction = _.map(toDelete, (category) =>
-                                 knex('data_categories')
-                                 .where({ name: category.name, group: category.group })
-                                 .del()
-                                 .then()
+      const deleteAction = _.map(toDelete, (category) => knex
+                                 .raw(`UPDATE data_contributions
+                                              SET data_category_id = null
+                                              WHERE data_category_id = (
+                                                SELECT id FROM data_categories WHERE name = '${category.name}');`)
+                                 .then(() =>
+                                       knex('data_categories')
+                                       .where({ name: category.name, group: category.group })
+                                       .del()
+                                       .then()
+                                      )
       );
 
       return replaceAction && deleteAction;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint *.js **/*.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "migrate": "knex migrate:latest",
+    "rollback": "knex migrate:rollback",
     "dev": "gulp dev",
     "prestart": "gulp build",
     "start": "node --optimize_for_size --max_old_space_size=460 --gc_interval=100 server.js"

--- a/views/contribute-data.html
+++ b/views/contribute-data.html
@@ -52,8 +52,12 @@
     <label for="data_category_id">Category</label>
     <select id="data_category_id" name="data_category_id">
       <option value="" disabled selected>Which category best describes your contribution?</option>
-      {% for category in categories %}
-      <option value="{{ category.id }}">{{ category.name }}</option>
+      {% for group, categories in  categories | sort(false, false, 'group') | groupby("group") %}
+      <optgroup label="{{ group }}">
+        {% for category in categories %}
+          <option value="{{ category.id }}">{{ category.name }}</option>
+        {% endfor %}
+      </optgroup>
       {% endfor %}
     </select>
 


### PR DESCRIPTION
Implement new categories structure in database, existing data and UI.

Some comments to be aware of before reviewing:

* all the publication related submissions have been merged under "Other" category and should be manually distributed to the many publication categories we have now (see #626)
* some other things are to be remapped to "Other", generally things that either have ambiguous destinations (category broken down to multiple pieces) or have neither contributions or remapping info available

This commit introduces two new migrations:

* one to add a `group` column to `data_categories`
* one to migrate existing contributions to the new categories (remapping)

They both have working `up` and `down` methods.

_P.S.: I also added a `npm run rollback` command to roll back migrations if we need. Just a minor thing that helps mostly in dev ;)_

![screenshot_20170105_110320](https://cloud.githubusercontent.com/assets/1579997/21674524/bf60cfaa-d336-11e6-91c2-598820c70e24.png)

opentrials/opentrials#558