### PR TITLE
Fix link and wording on OSP banner for OTFDA

### DIFF
--- a/views/fda/layouts/base.html
+++ b/views/fda/layouts/base.html
@@ -3,8 +3,8 @@
 
 {% block header %}
     <div class="ribbon">
-      <a href="http://event.capconcorp.com/wp/osp/vote-now/" rel="external" title="Vote for us on the Open Science Prize">
-        Vote for us!
+      <a href="http://opentrials.net/2017/01/10/opentrialsfda-voted-into-top-3-of-open-science-prize/" rel="external" title="OpenTrialsFDA voted into top 3 of Open Science Prize">
+        OSP finalist
       </a>
     </div>
   {% include "fda/partials/header.html" %}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1579997/21853753/06fb653e-d821-11e6-912b-0965606f4e7e.png)

Link goes to http://opentrials.net/2017/01/10/opentrialsfda-voted-into-top-3-of-open-science-prize/