### PR TITLE
[#671] Display "contribute data" text for missing lay summaries

### DIFF
--- a/views/trials-details.html
+++ b/views/trials-details.html
@@ -193,7 +193,7 @@
   {{ no_data_message('Interventions', thing='"intervention" data') }}
   {% endif %}
 
-  {% if trial.brief_summary.length != 0 %}
+  {% if trial.brief_summary != null %}
   <h2>
     Lay summary
   </h2>


### PR DESCRIPTION
Nunjucks doesn't play in the standard way with `null` and `undefined` values, so comparing it with `null` instead of measuring length fixed the issue we were having.